### PR TITLE
Improve handling of async operations, LESS imports

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -12,25 +12,48 @@ function convert(logger, projectDir, options) {
 		var lessFilesPath = path.join(projectDir, 'app/**/*.less');
 		var lessFiles = glob.sync(lessFilesPath).filter(function(fileName){
 			return fileName.indexOf("App_Resources") === -1;
-		});
-	
-		for(var i = 0; i < lessFiles.length; i++) {
-		    var filePath = lessFiles[i];
-			
-			var lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
-			less.render(lessFileContent, {
-				filename: filePath,
-				compress: true,
-				sync: true
-			}, function (e, output) {
-				if(e) {
-					reject(Error(filePath + ' LESS CSS pre-processing failed. Error: ' + e));
+		});    
+    
+		var i = 0;
+		var loopLessFilesAsync = function(lessFiles){
+			parseLess(lessFiles[i], function(e){
+				if(e !== undefined){
+					//Error in the LESS parser; Reject promise
+					reject(Error(lessFiles[i] + ' LESS CSS pre-processing failed. Error: ' + e));  
 				}
-				var cssFilePath = filePath.replace('.less', '.css');
-				fs.writeFile(cssFilePath, output.css, 'utf8');
+        
+				i++; //Increment loop counter
+        
+				if(i < lessFiles.length){
+					loopLessFilesAsync(lessFiles);
+				} else {
+					//All files have been processed; Resolve promise
+					resolve();
+				}
 			});
 		}
-		
-		resolve();
+    
+		loopLessFilesAsync(lessFiles);
+	});
+}
+
+function parseLess(filePath, callback){
+	var lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
+	less.render(lessFileContent, {
+		filename: filePath,
+		compress: true,
+		sync: true
+	}, function (e, output) {
+		if(e) {
+			//Callback with error
+			callback(e);
+		}           
+    
+		var cssFilePath = filePath.replace('.less', '.css');
+
+		fs.writeFile(cssFilePath, output.css, 'utf8', function(){
+			//File done writing
+			callback();
+		});                       
 	});
 }


### PR DESCRIPTION
The original version of the converter would allow race conditions due to the async behavior of `less.render` and `fs.writeFile.` This was problem was particularly clear when working with LESS imports. This refactoring ensures each file finishes LESS processing and file writing before iterating to the next in the array. With this change, LESS imports now behave as expected.
