### PR TITLE
Fix infinite loop of `tns run`

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -58,9 +58,13 @@ function parseLess(filePath, callback){
 
 		var cssFilePath = filePath.replace('.less', '.css');
 
-		fs.writeFile(cssFilePath, output.css, 'utf8', function(){
-			//File done writing
-			callback();
-		});
+		var currentContent = fs.existsSync(cssFilePath) ? fs.readFileSync(cssFilePath).toString() : null;
+		if (currentContent !== output.css) {
+			// Overwrite file only in case the new content is not the same as current one.
+			// This prevents infinite loop of `tns run` command.
+			fs.writeFileSync(cssFilePath, output.css, 'utf8');
+		}
+
+		callback();
 	});
 }


### PR DESCRIPTION
When you have devices with different platorm, since NativeScript CLI 3.1.3, you can use `tns run` command to run your app simultaneously on all devices.
However, when a change is applied, CLI prepares the project for the first platform (for example iOS) and syncs it to all available iOS devices and simulators.
After that, the project is prepared for the other platform (Android in this case) and syncs the changes to all available Android devices and emulators.
The first prepare (for iOS) will parse all `.less` files and will create `.css` files for each of them.
The second prepare (for Android) will do the same and will rewrite the files. At this point CLI is watching for file changes and will detect the new `.css` files (they have the same content, but they are newly created files, as the plugin is always writing) and will trigger new prepare steps.
And this continues indefinetely.
In order to fix it, check the content of the output.css file with the current content of the file and if they are the same, do not overwrite the file.
This way the first prepare (for iOS) will create all `.css` files, the prepare for Android will not overwrite them and CLI will not go into infinite loop.

Fixes NativeScript/nativescript-cli#3017