### PR TITLE
fix: converter fixes

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -1,5 +1,5 @@
 var converter = require('./converter');
 
 module.exports = function ($logger, $projectData, $usbLiveSyncService) {
-	return converter.convert($logger, $projectData.projectDir);
+	return converter.convert($logger, $projectData);
 }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,17 +1,24 @@
 exports.convert = convert;
 
-var fs = require('fs');
-var path = require('path');
-var less = require('less');
-var glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+const less = require('less');
+const glob = require('glob');
 
-function convert(logger, projectDir, options) {
+function convert(logger, $projectData) {
 	return new Promise(function (resolve, reject) {
-		options = options || {};
+		const appDirPath = $projectData.appDirectoryPath;
+		// NOTE: path.join will convert the `/` to correct ones based on the current OS
+		const lessFilesPath = path.join(appDirPath, '/**/*.less');
 
-		var lessFilesPath = path.join(projectDir, 'app/**/*.less');
-		var lessFiles = glob.sync(lessFilesPath).filter(function (fileName) {
-			return fileName.indexOf("App_Resources") === -1;
+		let appResourcesDirectoryPath = $projectData.appResourcesDirectoryPath;
+		if (process.platform === "win32") {
+			// glob returns all paths with UNIX style, i.e. with `/` instead of `\`, so ensure we use correct path for comparison
+			appResourcesDirectoryPath = appResourcesDirectoryPath.replace(/\\/g, "/");
+		}
+
+		const lessFiles = glob.sync(lessFilesPath).filter(function (fileName) {
+			return fileName.indexOf(appResourcesDirectoryPath) === -1;
 		});
 
 		if (!lessFiles || lessFiles.length === 0) {
@@ -20,8 +27,8 @@ function convert(logger, projectDir, options) {
 			return;
 		}
 
-		var i = 0;
-		var loopLessFilesAsync = function (lessFiles) {
+		let i = 0;
+		const loopLessFilesAsync = function (lessFiles) {
 			parseLess(lessFiles[i], function (e) {
 				if (e !== undefined) {
 					//Error in the LESS parser; Reject promise
@@ -44,7 +51,7 @@ function convert(logger, projectDir, options) {
 }
 
 function parseLess(filePath, callback) {
-	var lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
+	const lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
 	less.render(lessFileContent, {
 		filename: filePath,
 		compress: true,
@@ -62,9 +69,9 @@ function parseLess(filePath, callback) {
 			return;
 		}
 
-		var cssFilePath = filePath.replace('.less', '.css');
+		const cssFilePath = filePath.replace('.less', '.css');
 
-		var currentContent = fs.existsSync(cssFilePath) ? fs.readFileSync(cssFilePath).toString() : null;
+		const currentContent = fs.existsSync(cssFilePath) ? fs.readFileSync(cssFilePath).toString() : null;
 		if (currentContent !== output.css) {
 			// Overwrite file only in case the new content is not the same as current one.
 			// This prevents infinite loop of `tns run` command.

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -10,21 +10,27 @@ function convert(logger, projectDir, options) {
 		options = options || {};
 
 		var lessFilesPath = path.join(projectDir, 'app/**/*.less');
-		var lessFiles = glob.sync(lessFilesPath).filter(function(fileName){
+		var lessFiles = glob.sync(lessFilesPath).filter(function (fileName) {
 			return fileName.indexOf("App_Resources") === -1;
 		});
 
+		if (!lessFiles || lessFiles.length === 0) {
+			logger.trace(`Unable to find any '.less' files matching pattern: ${lessFilesPath}. nativescript-dev-less plugin will not do anything`);
+			resolve();
+			return;
+		}
+
 		var i = 0;
-		var loopLessFilesAsync = function(lessFiles){
-			parseLess(lessFiles[i], function(e){
-				if(e !== undefined){
+		var loopLessFilesAsync = function (lessFiles) {
+			parseLess(lessFiles[i], function (e) {
+				if (e !== undefined) {
 					//Error in the LESS parser; Reject promise
 					reject(Error(lessFiles[i] + ' LESS CSS pre-processing failed. Error: ' + e));
 				}
 
 				i++; //Increment loop counter
 
-				if(i < lessFiles.length){
+				if (i < lessFiles.length) {
 					loopLessFilesAsync(lessFiles);
 				} else {
 					//All files have been processed; Resolve promise
@@ -37,20 +43,20 @@ function convert(logger, projectDir, options) {
 	});
 }
 
-function parseLess(filePath, callback){
-	var lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8'});
+function parseLess(filePath, callback) {
+	var lessFileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
 	less.render(lessFileContent, {
 		filename: filePath,
 		compress: true,
 		sync: true
 	}, function (e, output) {
-		if(e) {
+		if (e) {
 			//Callback with error
 			callback(e);
 			return;
 		}
 
-		if(!output.css) {
+		if (!output.css) {
 			// No CSS to write to file, so just call callback without creating the file.
 			callback();
 			return;


### PR DESCRIPTION
### fix: error is thrown when no `.less` files are found

In case there are no `.less` files in the application, the plugin's hook will fail with error `The "path" argument must be one of type string, Buffer, or URL. Received type undefined`
The problem is that we iterrate over elements of empty array, so the `arr[0]` is undefined and the `path.join` operation fails.
Fix this by skipping the transpilation when there aren't `.less` files in the application.
Fixes issue: https://github.com/NativeScript/nativescript-dev-less/issues/13

### fix: support projects with nsconfig.json

Support projects with nsconfig.json files - currently they cannot be used as the `nativescript-dev-less` plugin always checks `app` dir for `.less` files.
Also fix the check if the files is from `App_Resources` dir - currently it is not working on Windows as the `glob` always returns UNIX style paths, but we compare them with Windows style ones.
Fixes issue: https://github.com/NativeScript/nativescript-dev-less/issues/15
